### PR TITLE
Add a check for '@' in safeId()

### DIFF
--- a/jquery.facetview2.js
+++ b/jquery.facetview2.js
@@ -80,7 +80,7 @@ if (!Array.prototype.indexOf) {
 })(jQuery);
 
 function safeId(s) {
-    return s.replace(/\./gi,'_').replace(/\:/gi,'_')
+    return s.replace(/\./gi,'_').replace(/\:/gi,'_').replace(/@/, '_');
 }
 
 // get the right facet element from the page


### PR DESCRIPTION
Logstash has field name with @, which disrupts jQuery selectors.

This PR fix the bug when a fieldname of a facet has a '@'.
With a '@' facet values was not displayed.
